### PR TITLE
Job Build request needs to be a POST

### DIFF
--- a/jenkins.js
+++ b/jenkins.js
@@ -62,11 +62,13 @@ module.exports = function(opts) {
     }
     defaults('url', api.url + path)
 
-    if (opts.hasOwnProperty('body') || opts.hasOwnProperty('body')) {
-      opts.method = 'POST'
-    } else {
-      opts.method = 'GET'
-      defaults('json', true)
+    if( !opts.method ) {
+      if (opts.hasOwnProperty('body') || opts.hasOwnProperty('body')) {
+        opts.method = 'POST'
+      } else {
+        opts.method = 'GET'
+        defaults('json', true)
+      }
     }
 
     opts.headers = opts.headers || {}
@@ -144,6 +146,7 @@ module.exports = function(opts) {
         o.qs = { token: opts.token }
       }
     }
+    o.method = 'POST'
     api.request(p, o, function(err, res) {
       if (err) return cb(err)
       if (res.statusCode == 404) return cb(notFound('job', name, res))

--- a/test/unit.js
+++ b/test/unit.js
@@ -128,8 +128,8 @@ describe('jenkins', function() {
     describe('build', function() {
       it('should work', function(done) {
         var api = test(done)
-                      .get('/job/nodejs-jenkins-test/build')
-                      .reply(302, assets.url + '/job/nodejs-jenkins-test')
+                      .post('/job/nodejs-jenkins-test/build')
+                      .reply(201, assets.url + '/job/nodejs-jenkins-test')
         jenkins.job.build('nodejs-jenkins-test', function(err) {
           assert.ifError(err)
           api.done()
@@ -138,8 +138,8 @@ describe('jenkins', function() {
 
       it('should work with a token', function(done) {
         var api = test(done)
-                      .get('/job/nodejs-jenkins-test/build?token=secret')
-                      .reply(302, assets.url + '/job/nodejs-jenkins-test')
+                      .post('/job/nodejs-jenkins-test/build?token=secret')
+                      .reply(201, assets.url + '/job/nodejs-jenkins-test')
         jenkins.job.build('nodejs-jenkins-test', { token: 'secret' }, function(err) {
           assert.ifError(err)
           api.done()
@@ -148,8 +148,8 @@ describe('jenkins', function() {
 
       it('should work with parameters', function(done) {
         var api = test(done)
-                      .get('/job/nodejs-jenkins-test/buildWithParameters?hello=world')
-                      .reply(302, assets.url + '/job/nodejs-jenkins-test')
+                      .post('/job/nodejs-jenkins-test/buildWithParameters?hello=world')
+                      .reply(201, assets.url + '/job/nodejs-jenkins-test')
         jenkins.job.build('nodejs-jenkins-test', { parameters: { hello: 'world' } }, function(err) {
           assert.ifError(err)
           api.done()
@@ -158,8 +158,8 @@ describe('jenkins', function() {
 
       it('should work with a token and parameters', function(done) {
         var api = test(done)
-                      .get('/job/nodejs-jenkins-test/buildWithParameters?hello=world&token=secret')
-                      .reply(302, assets.url + '/job/nodejs-jenkins-test')
+                      .post('/job/nodejs-jenkins-test/buildWithParameters?hello=world&token=secret')
+                      .reply(201, assets.url + '/job/nodejs-jenkins-test')
         jenkins.job.build('nodejs-jenkins-test', { parameters: { hello: 'world' }, token: 'secret' }, function(err) {
           assert.ifError(err)
           api.done()


### PR DESCRIPTION
Thanks for the module. I noticed that it wasn't kicking off builds correctly, since the request was only a GET. Jenkins seems to kick off a build when the request is POST. 
