### PR TITLE
Correct location to main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
   "scripts": {
     "test": "./node_modules/.bin/jshint lib test && ./node_modules/.bin/jscs lib test && ./node_modules/.bin/mocha test/unit.js --timeout 15000"
   },
-  "main": "./jenkins"
+  "main": "./lib/jenkins"
 }


### PR DESCRIPTION
When loading node-jenkins via NPM, the `main` location is incorrect, resulting in the module not being loaded. You can reproduce this behaviour:

```
mkdir sometest && cd sometest
npm init  # and enter to all defaults
npm install jenkins --save
echo "require('jenkins');" > index.js
node index.js
```

You will probably get a `Cannot find module 'jenkins'` error. This is because the package.json points at just './jenkins' which, when used via a node_modules dir, becomes just `node_modules/jenkins/jenkins.js` rather than `node_modules/jenkins/lib/jenkins.js`.

This is also hinted at in the manual:
  http://nodejs.org/api/modules.html#modules_folders_as_modules
