### PR TITLE
Use POST when trying to stop build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -112,7 +112,7 @@ Build.prototype.stop = function(opts, callback) {
     return callback(this.jenkins._err(err, req));
   }
 
-  return this.jenkins._get(
+  return this.jenkins._post(
     req,
     middleware.notFound(opts.name + ' ' + opts.number),
     middleware.require302('failed to stop: ' + opts.name),

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -171,7 +171,7 @@ describe('jenkins', function() {
         self.nock
           .post('/job/' + self.jobName + '/build')
           .reply(201, '', { location: 'http://localhost:8080/queue/item/1/' })
-          .get('/job/' + self.jobName + '/1/stop')
+          .post('/job/' + self.jobName + '/1/stop')
           .reply(302);
 
         jobs.push(function(next) {


### PR DESCRIPTION
Otherwise (recent) Jenkins will throw 'Method Not Allowed' error.

Fixes #16