### PR TITLE
add queue item api

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,62 @@ Result
 }
 ```
 
+<a name="queue-item"></a>
+### jenkins.queue.item(options, callback)
+
+Lookup a queue item.
+
+Options
+
+ * number (Integer): queue item number
+
+Usage
+
+``` javascript
+jenkins.queue.item(130, function(err, data) {
+  if (err) throw err;
+
+  console.log('item', data);
+});
+```
+
+Result
+
+``` json
+{
+  "actions": [
+    {
+      "causes": [
+        {
+          "shortDescription": "Started by user anonymous",
+          "userId": null,
+          "userName": "anonymous"
+        }
+      ]
+    }
+  ],
+  "blocked": false,
+  "buildable": false,
+  "id": 130,
+  "inQueueSince": 1406363479853,
+  "params": "",
+  "stuck": false,
+  "task": {
+    "name": "test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18",
+    "url": "http://localhost:8080/job/test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18/",
+    "color": "blue"
+  },
+  "url": "queue/item/130/",
+  "why": null,
+  "executable" : {
+    "number" : 28,
+    "url" : "http://localhost:8080/job/test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18/28/"
+  }
+}
+```
+
+
+
 <a name="queue-cancel"></a>
 ### jenkins.queue.cancel(options, callback)
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -74,6 +74,10 @@ Queue.prototype.item = function(opts, callback) {
 
   utils.options(req, opts);
 
+  if (!opts.number) {
+    return callback(this.jenkins._err(new Error('number required'), req));
+  }
+
   return this.jenkins._get(req, middleware.body, callback);
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -31,7 +31,7 @@ Queue.prototype.list = function(opts, callback) {
     opts = opts || {};
   }
 
-  this.jenkins._log(['debug', 'build', 'list'], opts);
+  this.jenkins._log(['debug', 'queue', 'list'], opts);
 
   var req = {
     name: 'queue.list',
@@ -41,6 +41,33 @@ Queue.prototype.list = function(opts, callback) {
   utils.options(req, opts);
 
   return this.jenkins._get(req, middleware.bodyItem('items'), callback);
+};
+
+/**
+ * Get an individual queue item
+ */
+
+Queue.prototype.item = function(opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  } else {
+    opts = opts || {};
+  }
+
+  this.jenkins._log(['debug', 'queue', 'item'], opts);
+
+  var req = {
+    name: 'queue.item',
+    path: '/queue/item/{number}/api/json',
+    params: {
+      number: opts.number
+    }
+  };
+
+  utils.options(req, opts);
+
+  return this.jenkins._get(req, middleware.body, callback);
 };
 
 /**

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -48,10 +48,17 @@ Queue.prototype.list = function(opts, callback) {
  */
 
 Queue.prototype.item = function(opts, callback) {
-  if (typeof opts === 'function') {
+  var arg0 = typeof arguments[0];
+
+  if (arg0 === 'function') {
     callback = opts;
     opts = {};
   } else {
+    if (arg0 === 'string' || arg0 === 'number') {
+      opts = {
+        number: opts
+      };
+    }
     opts = opts || {};
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jenkins",
   "description": "Jenkins client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "main": "./lib",
   "dependencies": {
     "papi": "^0.25.0"

--- a/test/fixtures/queueItem.json
+++ b/test/fixtures/queueItem.json
@@ -1,0 +1,30 @@
+{
+  "actions": [
+    {
+      "causes": [
+        {
+          "shortDescription": "Started by user anonymous",
+          "userId": null,
+          "userName": "anonymous"
+        }
+      ]
+    }
+  ],
+  "blocked": false,
+  "buildable": false,
+  "id": 130,
+  "inQueueSince": 1406363479853,
+  "params": "",
+  "stuck": false,
+  "task": {
+    "name": "test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18",
+    "url": "http://localhost:8080/job/test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18/",
+    "color": "blue"
+  },
+  "url": "queue/item/130/",
+  "why": null,
+  "executable" : {
+    "number" : 28,
+    "url" : "http://localhost:8080/job/test-job-b7ef0845-6515-444c-96a1-d2266d5e0f18/28/"
+  }
+}

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -1167,6 +1167,14 @@ describe('jenkins', function() {
           done();
         });
       });
+
+      it('should require a number', function(done) {
+        this.jenkins.queue.item(null, function(err, data) {
+          should.not.exist(data);
+          should.exist(err);
+          done();
+        });
+      });
     });
 
     describe('get', function() {

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -1153,6 +1153,22 @@ describe('jenkins', function() {
       });
     });
 
+    describe('item', function() {
+      it('should return a queue item', function(done) {
+        this.nock
+          .get('/queue/item/130/api/json')
+          .reply(200, fixtures.queueItem);
+
+        this.jenkins.queue.item(130, function(err, data) {
+          if (err) return done(err);
+          data.should.have.property('id');
+          data.id.should.equal(130);
+
+          done();
+        });
+      });
+    });
+
     describe('get', function() {
       nit('should work', function(done) {
         this.nock

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -1626,6 +1626,7 @@ describe('jenkins', function() {
         '  - list (callback)',
         ' Queue',
         '  - list (callback)',
+        '  - item (callback)',
         '  - get (callback)',
         '  - cancel (callback)',
         ' View',


### PR DESCRIPTION
This adds a `jenkins.queue.item(itemId)` api. This is useful for looking up queued items that may have already been scheduled and are no longer returned by the `queue.list()` api.

This api fits in to the workflow described in [JENKINS-12827: api should return the build number that was queued.](https://issues.jenkins-ci.org/browse/JENKINS-12827?focusedCommentId=201381&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-201381)