### PR TITLE
Show example build with parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ jenkins.job.build('example', function(err) {
 });
 ```
 
+``` javascript
+jenkins.job.build('example', {parameters:{'exampleParamName':'exampleParamValue'}}, function(err) {
+  if (err) throw err;
+});
+```
+
 <a name="job-config-get"></a>
 ### jenkins.job.config(options, callback)
 


### PR DESCRIPTION
It was not very clear what kind of object that was required for the build method if the jenkins build requires params. 