### PR TITLE
Add support for Test Report plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,71 @@ jenkins.view.remove('example', 'jobExample', function(err) {
 });
 ```
 
+<a name="testReport-get"></a>
+### jenkins.testReport.get(options, callback)
+
+Get test report information.
+
+Options
+
+ * name (String): job name
+ * number (Integer): build number
+
+Usage
+
+``` javascript
+jenkins.testReport.get('example', 1, function(err, data) {
+  if (err) throw err;
+
+  console.log('build', data);
+});
+```
+
+Result
+
+``` json
+{
+  "failCount": 0,
+  "skipCount": 25,
+  "totalCount": 149,
+  "urlName": "testReport",
+  "childReports": [
+    {
+      "child": {
+        "number": 1,
+        "url": "http://localhost:8080/job/test-7ea39228-5841-4a0f-b83c-1d971713f9c6/child/1/"
+      },
+      "result": {
+        "duration": 799.911,
+        "empty": false,
+        "failCount": 0,
+        "passCount": 107,
+        "skipCount": 21,
+        "suites": [
+          {
+            "cases": [
+              {
+                "age": 0,
+                "className": "SomeClass",
+                "duration": 9.172,
+                "failedSince": 0,
+                "name": "it should display something",
+                "skipped": false,
+                "status": "PASSED"
+              }
+            ],
+            "duration": 9.172,
+            "id": null,
+            "name": "SomeClass",
+            "timestamp": "2016-12-12T16:09:43"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## License
 
 This work is licensed under the MIT License (see the LICENSE file).

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -17,6 +17,7 @@ var Job = require('./job').Job;
 var Node = require('./node').Node;
 var Queue = require('./queue').Queue;
 var View = require('./view').View;
+var TestReport = require('./test_report').TestReport;
 var middleware = require('./middleware');
 var utils = require('./utils');
 
@@ -74,6 +75,7 @@ function Jenkins(opts) {
   this.node = new Jenkins.Node(this);
   this.queue = new Jenkins.Queue(this);
   this.view = new Jenkins.View(this);
+  this.testReport = new Jenkins.TestReport(this);
 
   try {
     if (opts.promisify) {
@@ -97,6 +99,7 @@ Jenkins.Job = Job;
 Jenkins.Node = Node;
 Jenkins.Queue = Queue;
 Jenkins.View = View;
+Jenkins.TestReport = TestReport;
 
 /**
  * Object meta

--- a/lib/test_report.js
+++ b/lib/test_report.js
@@ -8,7 +8,6 @@
  * Module dependencies.
  */
 
-var LogStream = require('./log_stream').LogStream;
 var middleware = require('./middleware');
 var utils = require('./utils');
 

--- a/lib/test_report.js
+++ b/lib/test_report.js
@@ -1,0 +1,114 @@
+/**
+ * Test Report client
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var LogStream = require('./log_stream').LogStream;
+var middleware = require('./middleware');
+var utils = require('./utils');
+
+/**
+ * Initialize a new `TestReport` client.
+ */
+
+function TestReport(jenkins) {
+  this.jenkins = jenkins;
+}
+
+/**
+ * Object meta
+ */
+
+TestReport.meta = {};
+
+/**
+ * TestReport details
+ */
+
+TestReport.prototype.get = function(opts, callback) {
+  var arg0 = typeof arguments[0];
+  var arg1 = typeof arguments[1];
+  var arg2 = typeof arguments[2];
+  var arg3 = typeof arguments[3];
+
+  if (arg0 === 'string' && (arg1 === 'string' || arg1 === 'number')) {
+    if (arg2 === 'object') {
+      opts = arguments[2];
+      callback = arg3 === 'function' ? arguments[3] : undefined;
+    } else {
+      opts = {};
+      callback = arg2 === 'function' ? arguments[2] : undefined;
+    }
+
+    opts.name = arguments[0];
+    opts.number = arguments[1];
+  } else {
+    opts = opts || {};
+  }
+
+  this.jenkins._log(['debug', 'testReport', 'get'], opts);
+
+  var req = { name: 'build.get' };
+
+  utils.options(req, opts);
+
+  try {
+    var folder = utils.FolderPath(opts.name);
+
+    if (folder.isEmpty()) throw new Error('name required');
+    if (!opts.number) throw new Error('number required');
+
+    req.path = '{folder}/{number}/testReport/api/json';
+    req.params = {
+      folder: folder.path(),
+      number: opts.number,
+    };
+  } catch (err) {
+    return callback(this.jenkins._err(err, req));
+  }
+
+  return this.jenkins._get(
+    req,
+    middleware.notFound(opts.name + ' ' + opts.number),
+    middleware.body,
+    callback
+  );
+};
+
+/**
+* Get log stream
+*/
+
+TestReport.meta.logStream = { type: 'eventemitter' };
+
+TestReport.prototype.logStream = function(opts) {
+  var arg0 = typeof arguments[0];
+  var arg1 = typeof arguments[1];
+  var arg2 = typeof arguments[2];
+
+  if (arg0 === 'string' && (arg1 === 'string' || arg1 === 'number')) {
+    if (arg2 === 'object') {
+      opts = arguments[2];
+    } else {
+      opts = {};
+    }
+
+    opts.name = arguments[0];
+    opts.number = arguments[1];
+  } else {
+    opts = opts || {};
+  }
+
+  return new LogStream(this.jenkins, opts);
+};
+
+/**
+ * Module exports.
+ */
+
+exports.TestReport = TestReport;

--- a/lib/test_report.js
+++ b/lib/test_report.js
@@ -53,7 +53,7 @@ TestReport.prototype.get = function(opts, callback) {
 
   this.jenkins._log(['debug', 'testReport', 'get'], opts);
 
-  var req = { name: 'build.get' };
+  var req = { name: 'testReport.get' };
 
   utils.options(req, opts);
 
@@ -78,33 +78,6 @@ TestReport.prototype.get = function(opts, callback) {
     middleware.body,
     callback
   );
-};
-
-/**
-* Get log stream
-*/
-
-TestReport.meta.logStream = { type: 'eventemitter' };
-
-TestReport.prototype.logStream = function(opts) {
-  var arg0 = typeof arguments[0];
-  var arg1 = typeof arguments[1];
-  var arg2 = typeof arguments[2];
-
-  if (arg0 === 'string' && (arg1 === 'string' || arg1 === 'number')) {
-    if (arg2 === 'object') {
-      opts = arguments[2];
-    } else {
-      opts = {};
-    }
-
-    opts.name = arguments[0];
-    opts.number = arguments[1];
-  } else {
-    opts = opts || {};
-  }
-
-  return new LogStream(this.jenkins, opts);
 };
 
 /**

--- a/test/fixtures/testReportGet.json
+++ b/test/fixtures/testReportGet.json
@@ -1,0 +1,40 @@
+{
+  "failCount": 0,
+  "skipCount": 25,
+  "totalCount": 149,
+  "urlName": "testReport",
+  "childReports": [
+    {
+      "child": {
+        "number": 1,
+        "url": "http://localhost:8080/job/test-7ea39228-5841-4a0f-b83c-1d971713f9c6/child/1/"
+      },
+      "result": {
+        "duration": 799.911,
+        "empty": false,
+        "failCount": 0,
+        "passCount": 107,
+        "skipCount": 21,
+        "suites": [
+          {
+            "cases": [
+              {
+                "age": 0,
+                "className": "SomeClass",
+                "duration": 9.172,
+                "failedSince": 0,
+                "name": "it should display something",
+                "skipped": false,
+                "status": "PASSED"
+              }
+            ],
+            "duration": 9.172,
+            "id": null,
+            "name": "SomeClass",
+            "timestamp": "2016-12-12T16:09:43"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -1662,8 +1662,7 @@ describe('jenkins', function() {
         '  - add (callback)',
         '  - remove (callback)',
         ' TestReport',
-        '  - get (callback)',
-        '  - logStream (eventemitter)'
+        '  - get (callback)'
       ]);
     });
   });


### PR DESCRIPTION
This allows to retrieve `{job}/{build}/testReport/` objects from [Test Results Analyzer Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Test+Results+Analyzer+Plugin)