### PR TITLE
Add mention about additional options for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options
  * crumbIssuer (Boolean, default: false): enable CSRF Protection support
  * headers (Object, optional): headers included in every request
  * promisify (Boolean|Function, optional): convert callback methods to promises
+ * Others options like: agent, pfx, key, passphrase, cert, ca, ciphers, rejectUnauthorized, secureProtocol, timeout.
 
 Usage
 


### PR DESCRIPTION
After creation #39 i brute force search bar for any mentions about ssl, restrictions and cert. Hopfully i found thread #13.
I think it's common question and i add some hint in option paragraph for readme.