### PR TITLE
Don't ignore delay parameter of logStream function

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -216,6 +216,7 @@ Build.prototype.logStream = function(opts) {
       opts = arguments[2];
     } else {
       opts = {};
+      opts.delay = arguments[3];
     }
 
     opts.name = arguments[0];


### PR DESCRIPTION
In the documentation it says that there is a fourth parameter - `delay`. It's an interval for pulling logs from Jenkins.

Typings also respect this https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jenkins/index.d.ts#L18

In fact, this parameter is ignored and 1 second is always used.