### PR TITLE
Remove name option when listing jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -485,19 +485,6 @@ Job.prototype.list = function(opts, callback) {
 
   utils.options(req, opts);
 
-  if (opts.name) {
-    try {
-      var folder = utils.FolderPath(opts.name);
-
-      if (folder.isEmpty()) throw new Error('name required');
-
-      req.path = '{folder}/api/json';
-      req.params = { folder: folder.path() };
-    } catch (err) {
-      return callback(this.jenkins._err(err, req));
-    }
-  }
-
   return this.jenkins._get(
     req,
     function(ctx, next) {

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -733,50 +733,6 @@ describe('jenkins', function() {
         });
       });
 
-      it('should list jobs with string options', function(done) {
-        var self = this;
-
-        self.nock
-          .get('/job/test/api/json')
-          .reply(200, fixtures.jobList);
-
-        self.jenkins.job.list('test', function(err, data) {
-          should.not.exist(err);
-
-          should.exist(data);
-
-          data.should.not.be.empty;
-
-          data.forEach(function(job) {
-            job.should.have.properties('name');
-          });
-
-          done();
-        });
-      });
-
-      it('should list jobs with object options', function(done) {
-        var self = this;
-
-        self.nock
-          .get('/job/test/api/json')
-          .reply(200, fixtures.jobList);
-
-        self.jenkins.job.list({ name: ['test'] }, function(err, data) {
-          should.not.exist(err);
-
-          should.exist(data);
-
-          data.should.not.be.empty;
-
-          data.forEach(function(job) {
-            job.should.have.properties('name');
-          });
-
-          done();
-        });
-      });
-
       nit('should handle corrupt responses', function(done) {
         var data = '"trash';
 


### PR DESCRIPTION
The acceptance tests were failing.
In attempting to make them pass, I concluded they couldn't ever
work.

As it was, the acceptance tests were 404ing, on URLs like:
`/job/test/api/json`. This was because there is no job called `test`. If
it was changed to search for `this.jobName`, then it would make a
successful request. But the response type would be different - it wouldn't
have the `jobs` array field that the following code looks for.

I can't find anyway to filter the `/api/json` route by jobname.
As such, I think it's better to just get rid of the option, as it can't
be supported.