### PR TITLE
Generate type definition on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ hack.*
 node_modules
 package-lock.json
 tmp
+types

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "version": "1.0.2",
   "main": "./lib",
   "files": [
-    "./lib"
+    "./lib",
+    "./types"
   ],
+  "types": "types/index.d.ts",
   "dependencies": {
     "papi": "^1.1.0"
   },
@@ -20,9 +22,11 @@
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
     "should": "^13.2.1",
-    "sinon": "^14.0.0"
+    "sinon": "^14.0.0",
+    "typescript": "^5.1.3"
   },
   "scripts": {
+    "prepublishOnly": "tsc",
     "format": "prettier -w .",
     "test": "prettier -c . && nyc mocha -- --recursive --check-leaks --timeout 15000",
     "acceptance": "NOCK_OFF=true NOCK_REC=false JENKINS_TEST_URL=http://admin:admin@localhost:8080 mocha --recursive --check-leaks --timeout 15000"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["lib/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types"
+  }
+}


### PR DESCRIPTION
# Overview
This auto type definition generation does not make correct models for response object. But if help to remove TS complaints from target project.
The best way to have up-to-date TS def is convert this project to TS, which is depend on package owner decision :)

# Sample usage
## Create jenkins connection object
```ts
// The package here is my test package for this PR
import Jenkins = require('@trinhpham/jenkins');

const jenkinsConnection = new Jenkins(jenkinsUrl, {
  crumbIssuer: true,
});
```

## Get a queued item
```ts
const queuedItem = await jenkinsConnection.queue.item(buildNumber, undefined);
```

## Trigger a build
```ts
const data = await jenkinsConnection.job.build(jobName, {
  parameters: {
    PARAM1: myParam,
  },
});
```