### PR TITLE
fix: make the parameters of  job.build api correspond to @types/jenkins

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -10,7 +10,17 @@ class Job {
    * Trigger job build
    */
   async build(name, opts) {
-    opts = utils.parse([...arguments], "name");
+    if(arguments.length <= 1) {
+      opts = utils.parse([...arguments], "name")
+    } else if(arguments.length === 2) {
+      if(typeof arguments[arguments.length - 1] === 'object') {
+        opts = utils.parse([...arguments, {}], "name", 'parameters')
+      } else {
+        opts = utils.parse([...arguments], "name", 'token')
+      }
+    } else {
+      opts = utils.parse([...arguments], 'name', 'parameters', 'token')
+    }
 
     this.jenkins._log(["debug", "job", "build"], opts);
 


### PR DESCRIPTION
when we use this api like:

`await jenkins.build(jobName, parameters)`

it throws an error "nothing is submitted"

and we have to use like below:

`await jenkins.build(jobName, {parameters})`