### PR TITLE
Credentials API, create, exist config, destroy and list

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,29 +1,28 @@
 {
-    "version": "0.2.0",
-    "configurations": [
+  "version": "0.2.0",
+  "configurations": [
     {
       "type": "node",
       "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--recursive",
-        "--check-leaks",
-        "--timeout 15000"
-      ],
+      "args": ["--recursive", "--check-leaks", "--timeout 15000"],
       "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": [
-        "<node_internals>/**"
-      ]
+      "skipFiles": ["<node_internals>/**"]
     },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Program",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}/src/yourNodeIndex.js"
-        }
-    ]
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha No Nock",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--recursive", "--check-leaks", "--timeout 15000"],
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": ["<node_internals>/**"],
+      "env": {
+        "NOCK_OFF": "true",
+        "NOCK_REC": "false",
+        "JENKINS_TEST_URL": "http://admin:admin@localhost:8080"
+      }
+    },
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,6 @@
         "NOCK_REC": "false",
         "JENKINS_TEST_URL": "http://admin:admin@localhost:8080"
       }
-    },
+    }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--recursive",
+        "--check-leaks",
+        "--timeout 15000"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/src/yourNodeIndex.js"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is a Node.js client for [Jenkins](http://jenkins-ci.org/).
 
 - jenkins: [init](#init), [info](#info)
 - build: [get](#build-get), [log](#build-log), [logStream](#build-log-stream), [stop](#build-stop), [term](#build-term)
+- credentials: [create](#credentials-create), [exists](#credentials-exists), [get config](#credentials-get-config), [set config](#credentials-set-config), [destroy](#credentials-destroy), [list](#credentials-list)
 - job: [build](#job-build), [get config](#job-config-get), [set config](#job-config-set), [copy](#job-config-copy), [create](#job-create), [destroy](#job-destroy), [disable](#job-disable), [enable](#job-enable), [exists](#job-exists), [get](#job-get), [list](#job-list)
 - label: [get](#label-get)
 - node: [get config](#node-config-get), [create](#node-create), [destroy](#node-destroy), [disconnect](#node-disconnect), [disable](#node-disable), [enable](#node-enable), [exists](#node-exists), [get](#node-get), [list](#node-list)
 - plugin: [list](#plugin-list)
 - queue: [list](#queue-list), [item](#queue-item), [cancel](#queue-cancel)
 - view: [get config](#view-config-get), [set config](#view-config-set), [create](#view-create), [destroy](#view-destroy), [exists](#view-exists), [get](#view-get), [list](#view-list), [add job](#view-add), [remove job](#view-remove)
-- credentials: [create](#credential-create), [exists](#credential-exists), [get config](#credential-get-config), [set config](#credential-set-config), [destroy](#credential-destroy), [list](#credential-list)
 
 <a id="common-options"></a>
 
@@ -255,6 +255,120 @@ Usage
 
 ```javascript
 await jenkins.build.term("example", 1);
+```
+
+<a id="credentials-create"></a>
+
+### jenkins.credentials.create(options)
+
+Create credential in a folder or system.
+
+Options
+
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, can be `folder` or `system`
+- domain (String): domain where to create the credentials
+- xml (String): configuration XML
+
+Usage
+
+```javascript
+await jenkins.credentials.create("folder", "store", "domain", "xml");
+```
+
+<a id="credentials-exists"></a>
+
+### jenkins.credentials.exists(options)
+
+Check if the credential exist in a folder or system.
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, can be `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.exists("id", "folder", "store", "domain");
+```
+
+<a id="credentials-get-config"></a>
+
+### jenkins.credentials.config(options)
+
+Get XML configuration of a credential.
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, can be `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.config("id", "folder", "store", "domain");
+```
+
+<a id="credentials-set-config"></a>
+
+### jenkins.credentials.config(options)
+
+Update Credential
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, can be `folder` or `system`
+- domain (String): domain where to create the credentials
+- xml (String): configuration XML
+
+Usage
+
+```javascript
+await jenkins.credentials.exists("id", "folder", "store", "domain", "xml");
+```
+
+<a id="credentials-destroy"></a>
+
+### jenkins.credentials.destroy(options)
+
+Delete credentials from folder or system.
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.destroy("id", "folder", "store", "domain");
+```
+
+<a id="credentials-list"></a>
+
+### jenkins.credentials.list(options)
+
+Get a list of credentials in a folder or system.
+
+Options
+
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.list("folder", "store", "domain");
 ```
 
 <a id="job-build"></a>
@@ -1176,119 +1290,6 @@ Usage
 await jenkins.view.remove("example", "jobExample");
 ```
 
-<a id="credential-create"></a>
-
-### jenkins.credentials.create(options)
-
-Create credential in a folder or system.
-
-Options
-
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created,  can be `folder` or `system`
-- domain (String): domain where to create the credentials
-- xml (String): configuration XML
-
-Usage
-
-```javascript
-await jenkins.credentials.create("folder", "store", "domain", "xml")
-```
-
-<a id="credential-exists"></a>
-
-### jenkins.credentials.exists(options)
-
-Check if the credential exist in a folder or system.
-
-Options
-
-- id (String): the id of the credential
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created,  can be `folder` or `system`
-- domain (String): domain where to create the credentials
-
-Usage
-
-```javascript
-await jenkins.credentials.exists("id", "folder", "store", "domain")
-```
-
-<a id="credential-get-config"></a>
-
-### jenkins.credentials.config(options)
-
-Get XML configuration of a credential.
-
-Options
-
-- id (String): the id of the credential
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created,  can be `folder` or `system`
-- domain (String): domain where to create the credentials
-
-Usage
-
-```javascript
-await jenkins.credentials.config("id", "folder", "store", "domain")
-```
-
-<a id="credential-set-config"></a>
-
-### jenkins.credentials.config(options)
-
-Update Credential
-
-Options
-
-- id (String): the id of the credential
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created, can be `folder` or `system`
-- domain (String): domain where to create the credentials
-- xml (String): configuration XML
-
-Usage
-
-```javascript
-await jenkins.credentials.exists("id", "folder", "store", "domain", "xml")
-```
-
-<a id="credential-destroy"></a>
-
-### jenkins.credentials.destroy(options)
-
-Delete credentials from folder or system.
-
-Options
-
-- id (String): the id of the credential
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created, `folder` or `system`
-- domain (String): domain where to create the credentials
-
-Usage
-
-```javascript
-await jenkins.credentials.destroy("id", "folder", "store", "domain")
-```
-
-<a id="credential-list"></a>
-
-### jenkins.credentials.list(options)
-
-Get a list of credentials in a folder or system.
-
-Options
-
-- folder (String): path of the folder or `manage` for **system** credentials
-- store (String): the store where credentials should be created, `folder` or `system`
-- domain (String): domain where to create the credentials
-
-Usage
-
-```javascript
-await jenkins.credentials.list("folder", "store", "domain")
-```
 ## Test
 
 Run unit tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a Node.js client for [Jenkins](http://jenkins-ci.org/).
 - plugin: [list](#plugin-list)
 - queue: [list](#queue-list), [item](#queue-item), [cancel](#queue-cancel)
 - view: [get config](#view-config-get), [set config](#view-config-set), [create](#view-create), [destroy](#view-destroy), [exists](#view-exists), [get](#view-get), [list](#view-list), [add job](#view-add), [remove job](#view-remove)
-- credentials: 
+- credentials: [create](#credential-create), [exists](#credential-exists), [system create](#credential-system-create), [system exist](#credential-system-exists) 
 
 <a id="common-options"></a>
 
@@ -1175,6 +1175,80 @@ Usage
 ```javascript
 await jenkins.view.remove("example", "jobExample");
 ```
+
+<a id="credential-create"></a>
+
+### jenkins.credentials.create(options)
+
+Create credential in store & domain (Non System).
+
+Options
+
+- folder (String): path of the folder or 'manage' for system
+- store (String): the store where credentials should be created
+- domain (String): domain where to create the credentials
+- xml (String): configuration XML
+
+Usage
+
+```javascript
+await jenkins.credentials.create("folder", "store", "domain", xml)
+```
+
+<a id="credential-exists"></a>
+
+### jenkins.credentials.exists(options)
+
+Check if the credential exist (Non System).
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or 'manage' for system
+- store (String): the store where credentials should be created
+- domain (String): domain where to create the credentials
+- xml (String): configuration XML
+
+Usage
+
+```javascript
+await jenkins.credentials.exists("id", "folder", "store", "domain")
+```
+
+<a id="credential-system-create"></a>
+
+### jenkins.credentials.systemCreate(options)
+
+Create system credential in the domain.
+
+Options
+
+- domain (String): domain where to create the credentials
+- xml (String): configuration XML
+
+Usage
+
+```javascript
+await jenkins.credentials.systemCreate("domain", "xml")
+```
+
+<a id="credential-system-exists"></a>
+
+### jenkins.credentials.systemExist(options)
+
+Check if the system credential exist.
+
+Options
+
+- id (String): the id of the credential
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.systemExist("id", "domain")
+```
+
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a Node.js client for [Jenkins](http://jenkins-ci.org/).
 - plugin: [list](#plugin-list)
 - queue: [list](#queue-list), [item](#queue-item), [cancel](#queue-cancel)
 - view: [get config](#view-config-get), [set config](#view-config-set), [create](#view-create), [destroy](#view-destroy), [exists](#view-exists), [get](#view-get), [list](#view-list), [add job](#view-add), [remove job](#view-remove)
-- credentials: [create](#credential-create), [exists](#credential-exists), [system create](#credential-system-create), [system exist](#credential-system-exists) 
+- credentials: [create](#credential-create), [exists](#credential-exists), [get config](#credential-get-config), [set config](#credential-set-config), [destroy](#credential-destroy), [list](#credential-list)
 
 <a id="common-options"></a>
 
@@ -1180,34 +1180,33 @@ await jenkins.view.remove("example", "jobExample");
 
 ### jenkins.credentials.create(options)
 
-Create credential in store & domain (Non System).
+Create credential in a folder or system.
 
 Options
 
-- folder (String): path of the folder or 'manage' for system
-- store (String): the store where credentials should be created
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created,  can be `folder` or `system`
 - domain (String): domain where to create the credentials
 - xml (String): configuration XML
 
 Usage
 
 ```javascript
-await jenkins.credentials.create("folder", "store", "domain", xml)
+await jenkins.credentials.create("folder", "store", "domain", "xml")
 ```
 
 <a id="credential-exists"></a>
 
 ### jenkins.credentials.exists(options)
 
-Check if the credential exist (Non System).
+Check if the credential exist in a folder or system.
 
 Options
 
 - id (String): the id of the credential
-- folder (String): path of the folder or 'manage' for system
-- store (String): the store where credentials should be created
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created,  can be `folder` or `system`
 - domain (String): domain where to create the credentials
-- xml (String): configuration XML
 
 Usage
 
@@ -1215,41 +1214,81 @@ Usage
 await jenkins.credentials.exists("id", "folder", "store", "domain")
 ```
 
-<a id="credential-system-create"></a>
+<a id="credential-get-config"></a>
 
-### jenkins.credentials.systemCreate(options)
+### jenkins.credentials.config(options)
 
-Create system credential in the domain.
+Get XML configuration of a credential.
 
 Options
 
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created,  can be `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.config("id", "folder", "store", "domain")
+```
+
+<a id="credential-set-config"></a>
+
+### jenkins.credentials.config(options)
+
+Update Credential
+
+Options
+
+- id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, can be `folder` or `system`
 - domain (String): domain where to create the credentials
 - xml (String): configuration XML
 
 Usage
 
 ```javascript
-await jenkins.credentials.systemCreate("domain", "xml")
+await jenkins.credentials.exists("id", "folder", "store", "domain", "xml")
 ```
 
-<a id="credential-system-exists"></a>
+<a id="credential-destroy"></a>
 
-### jenkins.credentials.systemExist(options)
+### jenkins.credentials.destroy(options)
 
-Check if the system credential exist.
+Delete credentials from folder or system.
 
 Options
 
 - id (String): the id of the credential
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, `folder` or `system`
 - domain (String): domain where to create the credentials
 
 Usage
 
 ```javascript
-await jenkins.credentials.systemExist("id", "domain")
+await jenkins.credentials.destroy("id", "folder", "store", "domain")
 ```
 
+<a id="credential-list"></a>
 
+### jenkins.credentials.list(options)
+
+Get a list of credentials in a folder or system.
+
+Options
+
+- folder (String): path of the folder or `manage` for **system** credentials
+- store (String): the store where credentials should be created, `folder` or `system`
+- domain (String): domain where to create the credentials
+
+Usage
+
+```javascript
+await jenkins.credentials.list("folder", "store", "domain")
+```
 ## Test
 
 Run unit tests

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a Node.js client for [Jenkins](http://jenkins-ci.org/).
 - plugin: [list](#plugin-list)
 - queue: [list](#queue-list), [item](#queue-item), [cancel](#queue-cancel)
 - view: [get config](#view-config-get), [set config](#view-config-set), [create](#view-create), [destroy](#view-destroy), [exists](#view-exists), [get](#view-get), [list](#view-list), [add job](#view-add), [remove job](#view-remove)
+- credentials: 
 
 <a id="common-options"></a>
 

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -10,7 +10,14 @@ class Credentials {
    * Get or update config
    */
   async config(id, folderPath, store, domain, xml, opts) {
-    opts = utils.parse([...arguments], "id", "folder", "store", "domain", "xml");
+    opts = utils.parse(
+      [...arguments],
+      "id",
+      "folder",
+      "store",
+      "domain",
+      "xml"
+    );
 
     this.jenkins._log(["debug", "credentials", "config"], opts);
 
@@ -26,12 +33,13 @@ class Credentials {
       if (!opts.store) throw new Error("store is required");
       if (!opts.domain) throw new Error("domain is required");
 
-      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
+      req.path =
+        "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
       req.params = {
-        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        folder: store === "system" ? folder.path("/") : folder.path(),
         store: opts.store,
         domain: opts.domain,
-        id: opts.id
+        id: opts.id,
       };
 
       if (opts.xml) {
@@ -73,13 +81,14 @@ class Credentials {
       if (!opts.domain) throw new Error("domain required");
       if (!opts.xml) throw new Error("xml required");
 
-      req.path = "{folder}/credentials/store/{store}/domain/{domain}/createCredentials";
+      req.path =
+        "{folder}/credentials/store/{store}/domain/{domain}/createCredentials";
       req.headers = { "content-type": "text/xml; charset=utf-8" };
       req.params = {
-        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        folder: store === "system" ? folder.path("/") : folder.path(),
         store: opts.store,
         domain: opts.domain,
-        id: opts.id
+        id: opts.id,
       };
 
       req.body = Buffer.from(opts.xml);
@@ -107,12 +116,13 @@ class Credentials {
       if (!opts.store) throw new Error("store required");
       if (!opts.domain) throw new Error("domain required");
 
-      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
+      req.path =
+        "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
       req.params = {
-        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        folder: store === "system" ? folder.path("/") : folder.path(),
         store: opts.store,
         domain: opts.domain,
-        id: opts.id
+        id: opts.id,
       };
     } catch (err) {
       throw this.jenkins._err(err, req);
@@ -138,14 +148,14 @@ class Credentials {
       if (!opts.store) throw new Error("store is required");
       if (!opts.domain) throw new Error("domain is required");
 
-      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
+      req.path =
+        "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
       req.params = {
-        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        folder: store === "system" ? folder.path("/") : folder.path(),
         store: opts.store,
         domain: opts.domain,
-        id: opts.id
+        id: opts.id,
       };
-
     } catch (err) {
       throw this.jenkins._err(err, req);
     }
@@ -154,11 +164,11 @@ class Credentials {
   }
 
   async list(folderPath, store, domain, opts) {
-    opts = utils.parse([...arguments], "folder", "store",  "domain");
+    opts = utils.parse([...arguments], "folder", "store", "domain");
 
     this.jenkins._log(["debug", "credentials", "list"], opts);
 
-    const req = { 
+    const req = {
       name: "credentials.list",
     };
 
@@ -169,16 +179,17 @@ class Credentials {
 
       if (!opts.domain) opts.domain = "_";
 
-      req.path = "{folder}/credentials/store/{store}/domain/{domain}/api/json?tree=credentials[id]";
+      req.path =
+        "{folder}/credentials/store/{store}/domain/{domain}/api/json?tree=credentials[id]";
       req.params = {
-        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        folder: store === "system" ? folder.path("/") : folder.path(),
         store: opts.store,
-        domain: opts.domain
+        domain: opts.domain,
       };
     } catch (err) {
       throw this.jenkins._err(err, req);
     }
-    
+
     return await this.jenkins._get(
       req,
       (ctx, next) => {

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -9,44 +9,52 @@ class Credentials {
   /**
    * Get or update config
    */
-  // async config(path, store, domain, xml, opts) {
-  //   opts = utils.parse([...arguments], "name", "xml");
+  async config(id, folderPath, store, domain, xml, opts) {
+    opts = utils.parse([...arguments], "id", "folder", "store", "domain", "xml");
 
-  //   this.jenkins._log(["debug", "credentials", "config"], opts);
+    this.jenkins._log(["debug", "credentials", "config"], opts);
 
-  //   const req = { name: "credentials.config" };
+    const req = { name: "credentials.config" };
 
-  //   utils.options(req, opts);
+    utils.options(req, opts);
 
-  //   try {
-  //     const folder = utils.folderPath(opts.name);
+    try {
+      const folder = utils.folderPath(opts.folder);
 
-  //     if (folder.isEmpty()) throw new Error("name required");
+      if (folder.isEmpty()) throw new Error("folder is required");
+      if (!opts.id) throw new Error("id is required");
+      if (!opts.store) throw new Error("store is required");
+      if (!opts.domain) throw new Error("domain is required");
 
-  //     req.path = "{folder}/config.xml";
-  //     req.params = { folder: folder.path() };
+      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
+      req.params = {
+        folder: folder.path(),
+        store: opts.store,
+        domain: opts.domain,
+        id: opts.id
+      };
 
-  //     if (opts.xml) {
-  //       req.method = "POST";
-  //       req.headers = { "content-type": "text/xml; charset=utf-8" };
-  //       req.body = Buffer.from(opts.xml);
-  //     } else {
-  //       req.method = "GET";
-  //     }
-  //   } catch (err) {
-  //     throw this.jenkins._err(err, req);
-  //   }
+      if (opts.xml) {
+        req.method = "POST";
+        req.headers = { "content-type": "text/xml; charset=utf-8" };
+        req.body = Buffer.from(opts.xml);
+      } else {
+        req.method = "GET";
+      }
+    } catch (err) {
+      throw this.jenkins._err(err, req);
+    }
 
-  //   return await this.jenkins._request(
-  //     req,
-  //     middleware.notFound("job " + opts.name),
-  //     (ctx, next) => {
-  //       if (ctx.err || opts.xml) return middleware.empty(ctx, next);
+    return await this.jenkins._request(
+      req,
+      middleware.notFound("job " + opts.folder),
+      (ctx, next) => {
+        if (ctx.err || opts.xml) return middleware.empty(ctx, next);
 
-  //       next(false, ctx.res.body.toString("utf8"));
-  //     }
-  //   );
-  // }
+        next(false, ctx.res.body.toString("utf8"));
+      }
+    );
+  }
 
   async create(folder, store, domain, xml, opts) {
     opts = utils.parse([...arguments], "folder", "store", "domain", "xml");

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -28,7 +28,7 @@ class Credentials {
 
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
       req.params = {
-        folder: folder.path(),
+        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
         store: opts.store,
         domain: opts.domain,
         id: opts.id
@@ -76,7 +76,7 @@ class Credentials {
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/createCredentials";
       req.headers = { "content-type": "text/xml; charset=utf-8" };
       req.params = {
-        folder: folder.path(),
+        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
         store: opts.store,
         domain: opts.domain,
         id: opts.id
@@ -90,7 +90,7 @@ class Credentials {
     return await this.jenkins._post(req, middleware.empty);
   }
 
-  async exists(id, folder, store, domain, opts) {
+  async exists(id, folderPath, store, domain, opts) {
     opts = utils.parse([...arguments], "id", "folder", "store", "domain");
 
     this.jenkins._log(["debug", "credentials", "exists"], opts);
@@ -109,7 +109,7 @@ class Credentials {
 
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
       req.params = {
-        folder: folder.path(),
+        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
         store: opts.store,
         domain: opts.domain,
         id: opts.id
@@ -121,65 +121,80 @@ class Credentials {
     return await this.jenkins._head(req, middleware.exists);
   }
 
+  async destroy(id, folderPath, store, domain, opts) {
+    opts = utils.parse([...arguments], "id", "folder", "store", "domain");
 
-  async systemCreate(domain, xml, opts) {
-    opts = utils.parse([...arguments], "domain", "xml");
+    this.jenkins._log(["debug", "credentials", "destroy"], opts);
 
-    this.jenkins._log(["debug", "credentials", "systemCreate"], opts);
-
-    const req = { name: "credentials.systemCreate" };
+    const req = { name: "credentials.destroy" };
 
     utils.options(req, opts);
 
     try {
-      const folder = utils.folderPath("manage");
+      const folder = utils.folderPath(opts.folder);
 
-      if (!opts.domain) throw new Error("domain required");
-      if (!opts.xml) throw new Error("xml required");
+      if (folder.isEmpty()) throw new Error("folder is required");
+      if (!opts.id) throw new Error("id is required");
+      if (!opts.store) throw new Error("store is required");
+      if (!opts.domain) throw new Error("domain is required");
 
-      req.path = "{folder}/credentials/store/system/domain/{domain}/createCredentials";
-      req.headers = { "content-type": "text/xml; charset=utf-8" };
+      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/config.xml";
       req.params = {
-        folder: folder.pathWithoutSeperator(),
+        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
         store: opts.store,
         domain: opts.domain,
         id: opts.id
       };
 
-      req.body = Buffer.from(opts.xml);
     } catch (err) {
       throw this.jenkins._err(err, req);
     }
 
-    return await this.jenkins._post(req, middleware.empty);
+    return await this.jenkins._delete(req, middleware.empty);
   }
 
-  async systemExist(id, domain, opts) {
-    opts = utils.parse([...arguments], "id", "domain");
+  async list(folderPath, store, domain, opts) {
+    opts = utils.parse([...arguments], "folder", "store",  "domain");
 
-    this.jenkins._log(["debug", "credentials", "systemExist"], opts);
+    this.jenkins._log(["debug", "credentials", "list"], opts);
 
-    const req = { name: "credentials.systemExist" };
+    const req = { 
+      name: "credentials.list",
+    };
 
     utils.options(req, opts);
 
     try {
-      const folder = utils.folderPath("manage");
+      const folder = utils.folderPath(opts.folder);
 
-      if (!opts.id) throw new Error("id required");
-      if (!opts.domain) throw new Error("domain required");
+      if (!opts.domain) opts.domain = "_";
 
-      req.path = "{folder}/credentials/store/system/domain/{domain}/credential/{id}/api/json";
+      req.path = "{folder}/credentials/store/{store}/domain/{domain}/api/json?tree=credentials[id]";
       req.params = {
-        folder: folder.pathWithoutSeperator(),
-        domain: opts.domain,
-        id: opts.id
+        folder: store === "system" ? folder.pathWithoutSeperator() : folder.path(),
+        store: opts.store,
+        domain: opts.domain
       };
     } catch (err) {
       throw this.jenkins._err(err, req);
     }
+    
+    return await this.jenkins._get(
+      req,
+      (ctx, next) => {
+        if (ctx.err) return next();
 
-    return await this.jenkins._head(req, middleware.exists);
+        if (ctx.err || opts.xml) return middleware.empty(ctx, next);
+
+        if (!ctx.res.body || !Array.isArray(ctx.res.body.credentials)) {
+          ctx.err = new Error("returned bad data");
+        }
+
+        next();
+      },
+      middleware.bodyItem("credentials")
+    );
   }
 }
+
 exports.Credentials = Credentials;

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -1,0 +1,96 @@
+const middleware = require("./middleware");
+const utils = require("./utils");
+
+class Credentials {
+    constructor(jenkins) {
+      this.jenkins = jenkins;
+    }
+
+  /**
+   * Get or update config
+   */
+  // async config(path, store, domain, xml, opts) {
+  //   opts = utils.parse([...arguments], "name", "xml");
+
+  //   this.jenkins._log(["debug", "credentials", "config"], opts);
+
+  //   const req = { name: "credentials.config" };
+
+  //   utils.options(req, opts);
+
+  //   try {
+  //     const folder = utils.folderPath(opts.name);
+
+  //     if (folder.isEmpty()) throw new Error("name required");
+
+  //     req.path = "{folder}/config.xml";
+  //     req.params = { folder: folder.path() };
+
+  //     if (opts.xml) {
+  //       req.method = "POST";
+  //       req.headers = { "content-type": "text/xml; charset=utf-8" };
+  //       req.body = Buffer.from(opts.xml);
+  //     } else {
+  //       req.method = "GET";
+  //     }
+  //   } catch (err) {
+  //     throw this.jenkins._err(err, req);
+  //   }
+
+  //   return await this.jenkins._request(
+  //     req,
+  //     middleware.notFound("job " + opts.name),
+  //     (ctx, next) => {
+  //       if (ctx.err || opts.xml) return middleware.empty(ctx, next);
+
+  //       next(false, ctx.res.body.toString("utf8"));
+  //     }
+  //   );
+  // }
+
+  // async create(path, store, domain, xml, opts){
+  //   opts = utils.parse([...arguments], "name", "xml");
+
+  //   this.jenkins._log(["debug", "credentials", "createCredentials"], opts);
+
+  //   const req = { name: "credentials.createCredentials" };
+
+  //   utils.options(req, opts);
+  //   try {
+  //     const folder = utils.folderPath(opts.name);
+
+  //   } catch (err) {
+  //     throw this.jenkins._err(err, req);
+  //   }
+  // }
+
+  async exists(id, contextPath, store, domain, opts) {
+    opts = utils.parse([...arguments], "id", "contextPath", "store", "domain");
+
+    this.jenkins._log(["debug", "credentials", "exists"], opts);
+
+    const req = { name: "credentials.exists" };
+
+    utils.options(req, opts);
+
+    try {
+      const folder = utils.folderPath(opts.contextPath);
+
+      if (folder.isEmpty()) throw new Error("path required");
+
+      req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
+      req.params = { 
+        folder: folder.path(),
+        store: opts.store,
+        domain: opts.domain,
+        id: opts.id
+      };
+    } catch (err) {
+      throw this.jenkins._err(err, req);
+    }
+
+    return await this.jenkins._head(req, middleware.exists);
+  }
+}
+
+exports.Credentials = Credentials;

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -2,9 +2,9 @@ const middleware = require("./middleware");
 const utils = require("./utils");
 
 class Credentials {
-    constructor(jenkins) {
-      this.jenkins = jenkins;
-    }
+  constructor(jenkins) {
+    this.jenkins = jenkins;
+  }
 
   /**
    * Get or update config
@@ -48,8 +48,8 @@ class Credentials {
   //   );
   // }
 
-  async create(path, store, domain, xml, opts){
-    opts = utils.parse([...arguments], "contextPath", "store", "domain", "xml");
+  async create(folder, store, domain, xml, opts) {
+    opts = utils.parse([...arguments], "folder", "store", "domain", "xml");
 
     this.jenkins._log(["debug", "credentials", "create"], opts);
 
@@ -58,16 +58,16 @@ class Credentials {
     utils.options(req, opts);
 
     try {
-      const folder = utils.folderPath(opts.contextPath);
+      const folder = utils.folderPath(opts.folder);
 
-      if (folder.isEmpty()) throw new Error("contextPath required");
+      if (folder.isEmpty()) throw new Error("folder required");
       if (!opts.store) throw new Error("store required");
       if (!opts.domain) throw new Error("domain required");
       if (!opts.xml) throw new Error("xml required");
 
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/createCredentials";
       req.headers = { "content-type": "text/xml; charset=utf-8" };
-      req.params = { 
+      req.params = {
         folder: folder.path(),
         store: opts.store,
         domain: opts.domain,
@@ -82,8 +82,8 @@ class Credentials {
     return await this.jenkins._post(req, middleware.empty);
   }
 
-  async exists(id, contextPath, store, domain, opts) {
-    opts = utils.parse([...arguments], "id", "contextPath", "store", "domain");
+  async exists(id, folder, store, domain, opts) {
+    opts = utils.parse([...arguments], "id", "folder", "store", "domain");
 
     this.jenkins._log(["debug", "credentials", "exists"], opts);
 
@@ -92,15 +92,15 @@ class Credentials {
     utils.options(req, opts);
 
     try {
-      const folder = utils.folderPath(opts.contextPath);
+      const folder = utils.folderPath(opts.folder);
 
-      if (folder.isEmpty()) throw new Error("contextPath required");
+      if (folder.isEmpty()) throw new Error("folder required");
       if (!opts.id) throw new Error("id required");
       if (!opts.store) throw new Error("store required");
       if (!opts.domain) throw new Error("domain required");
 
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
-      req.params = { 
+      req.params = {
         folder: folder.path(),
         store: opts.store,
         domain: opts.domain,
@@ -112,6 +112,66 @@ class Credentials {
 
     return await this.jenkins._head(req, middleware.exists);
   }
-}
 
+
+  async systemCreate(domain, xml, opts) {
+    opts = utils.parse([...arguments], "domain", "xml");
+
+    this.jenkins._log(["debug", "credentials", "systemCreate"], opts);
+
+    const req = { name: "credentials.systemCreate" };
+
+    utils.options(req, opts);
+
+    try {
+      const folder = utils.folderPath("manage");
+
+      if (!opts.domain) throw new Error("domain required");
+      if (!opts.xml) throw new Error("xml required");
+
+      req.path = "{folder}/credentials/store/system/domain/{domain}/createCredentials";
+      req.headers = { "content-type": "text/xml; charset=utf-8" };
+      req.params = {
+        folder: folder.pathWithoutSeperator(),
+        store: opts.store,
+        domain: opts.domain,
+        id: opts.id
+      };
+
+      req.body = Buffer.from(opts.xml);
+    } catch (err) {
+      throw this.jenkins._err(err, req);
+    }
+
+    return await this.jenkins._post(req, middleware.empty);
+  }
+
+  async systemExist(id, domain, opts) {
+    opts = utils.parse([...arguments], "id", "domain");
+
+    this.jenkins._log(["debug", "credentials", "systemExist"], opts);
+
+    const req = { name: "credentials.systemExist" };
+
+    utils.options(req, opts);
+
+    try {
+      const folder = utils.folderPath("manage");
+
+      if (!opts.id) throw new Error("id required");
+      if (!opts.domain) throw new Error("domain required");
+
+      req.path = "{folder}/credentials/store/system/domain/{domain}/credential/{id}/api/json";
+      req.params = {
+        folder: folder.pathWithoutSeperator(),
+        domain: opts.domain,
+        id: opts.id
+      };
+    } catch (err) {
+      throw this.jenkins._err(err, req);
+    }
+
+    return await this.jenkins._head(req, middleware.exists);
+  }
+}
 exports.Credentials = Credentials;

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -48,21 +48,39 @@ class Credentials {
   //   );
   // }
 
-  // async create(path, store, domain, xml, opts){
-  //   opts = utils.parse([...arguments], "name", "xml");
+  async create(path, store, domain, xml, opts){
+    opts = utils.parse([...arguments], "contextPath", "store", "domain", "xml");
 
-  //   this.jenkins._log(["debug", "credentials", "createCredentials"], opts);
+    this.jenkins._log(["debug", "credentials", "create"], opts);
 
-  //   const req = { name: "credentials.createCredentials" };
+    const req = { name: "credentials.create" };
 
-  //   utils.options(req, opts);
-  //   try {
-  //     const folder = utils.folderPath(opts.name);
+    utils.options(req, opts);
 
-  //   } catch (err) {
-  //     throw this.jenkins._err(err, req);
-  //   }
-  // }
+    try {
+      const folder = utils.folderPath(opts.contextPath);
+
+      if (folder.isEmpty()) throw new Error("contextPath required");
+      if (!opts.store) throw new Error("store required");
+      if (!opts.domain) throw new Error("domain required");
+      if (!opts.xml) throw new Error("xml required");
+
+      req.path = "{folder}/credentials/store/{store}/domain/{domain}/createCredentials";
+      req.headers = { "content-type": "text/xml; charset=utf-8" };
+      req.params = { 
+        folder: folder.path(),
+        store: opts.store,
+        domain: opts.domain,
+        id: opts.id
+      };
+
+      req.body = Buffer.from(opts.xml);
+    } catch (err) {
+      throw this.jenkins._err(err, req);
+    }
+
+    return await this.jenkins._post(req, middleware.empty);
+  }
 
   async exists(id, contextPath, store, domain, opts) {
     opts = utils.parse([...arguments], "id", "contextPath", "store", "domain");
@@ -76,7 +94,10 @@ class Credentials {
     try {
       const folder = utils.folderPath(opts.contextPath);
 
-      if (folder.isEmpty()) throw new Error("path required");
+      if (folder.isEmpty()) throw new Error("contextPath required");
+      if (!opts.id) throw new Error("id required");
+      if (!opts.store) throw new Error("store required");
+      if (!opts.domain) throw new Error("domain required");
 
       req.path = "{folder}/credentials/store/{store}/domain/{domain}/credential/{id}/api/json";
       req.params = { 

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -9,6 +9,7 @@ const Node = require("./node").Node;
 const Plugin = require("./plugin").Plugin;
 const Queue = require("./queue").Queue;
 const View = require("./view").View;
+const Credentials = require("./credentials").Credentials;
 const middleware = require("./middleware");
 const utils = require("./utils");
 
@@ -59,6 +60,7 @@ class Jenkins extends papi.Client {
     this.plugin = new Jenkins.Plugin(this);
     this.queue = new Jenkins.Queue(this);
     this.view = new Jenkins.View(this);
+    this.credentials = new Jenkins.Credentials(this);
   }
 
   /**
@@ -123,5 +125,6 @@ Jenkins.Node = Node;
 Jenkins.Plugin = Plugin;
 Jenkins.Queue = Queue;
 Jenkins.View = View;
+Jenkins.Credentials = Credentials;
 
 exports.Jenkins = Jenkins;

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -53,6 +53,7 @@ class Jenkins extends papi.Client {
     this._ext("onResponse", this._onResponse);
 
     this.build = new Jenkins.Build(this);
+    this.credentials = new Jenkins.Credentials(this);
     this.crumbIssuer = new Jenkins.CrumbIssuer(this);
     this.job = new Jenkins.Job(this);
     this.label = new Jenkins.Label(this);
@@ -60,7 +61,6 @@ class Jenkins extends papi.Client {
     this.plugin = new Jenkins.Plugin(this);
     this.queue = new Jenkins.Queue(this);
     this.view = new Jenkins.View(this);
-    this.credentials = new Jenkins.Credentials(this);
   }
 
   /**
@@ -118,6 +118,7 @@ class Jenkins extends papi.Client {
 }
 
 Jenkins.Build = Build;
+Jenkins.Credentials = Credentials;
 Jenkins.CrumbIssuer = CrumbIssuer;
 Jenkins.Job = Job;
 Jenkins.Label = Label;
@@ -125,6 +126,5 @@ Jenkins.Node = Node;
 Jenkins.Plugin = Plugin;
 Jenkins.Queue = Queue;
 Jenkins.View = View;
-Jenkins.Credentials = Credentials;
 
 exports.Jenkins = Jenkins;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,6 +100,14 @@ class FolderPath {
     );
   }
 
+  pathWithoutSeperator(){
+    if (this.isEmpty()) return new RawParam();
+
+    return new RawParam(
+      "/" + this.value.map(encodeURIComponent)
+    );
+  }
+
   parent() {
     return new FolderPath(
       this.value.slice(0, Math.max(0, this.value.length - 1))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,20 +92,11 @@ class FolderPath {
     return this.value[this.value.length - 1] || "";
   }
 
-  path() {
+  path(sep) {
     if (this.isEmpty()) return new RawParam();
+    if (!sep) sep = this.SEP;
 
-    return new RawParam(
-      this.SEP + this.value.map(encodeURIComponent).join(this.SEP)
-    );
-  }
-
-  pathWithoutSeperator(){
-    if (this.isEmpty()) return new RawParam();
-
-    return new RawParam(
-      "/" + this.value.map(encodeURIComponent)
-    );
+    return new RawParam(sep + this.value.map(encodeURIComponent).join(sep));
   }
 
   parent() {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -9,4 +9,4 @@ ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
 COPY setup.groovy /usr/share/jenkins/ref/init.groovy.d/setup.groovy
 COPY scriptApproval.xml /var/jenkins_home/scriptApproval.xml
 
-RUN jenkins-plugin-cli --plugins "jdk-tool script-security command-launcher cloudbees-folder"
+RUN jenkins-plugin-cli --plugins "jdk-tool script-security command-launcher cloudbees-folder credentials"

--- a/test/fixtures/credentialCreate.xml
+++ b/test/fixtures/credentialCreate.xml
@@ -1,6 +1,6 @@
 <com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
   <scope>GLOBAL</scope>
-  <id>my-credentials-example-id</id>
+  <id>user-new-cred</id>
   <description>This is an example from REST API</description>
   <username>admin</username>
   <password>

--- a/test/fixtures/credentialList.json
+++ b/test/fixtures/credentialList.json
@@ -1,0 +1,8 @@
+{
+    "_class": "com.cloudbees.plugins.credentials.CredentialsStoreAction$DomainWrapper",
+    "credentials": [
+        {
+            "id": "user-new-cred"
+        }
+    ]
+}

--- a/test/fixtures/credentialList.json
+++ b/test/fixtures/credentialList.json
@@ -1,8 +1,8 @@
 {
-    "_class": "com.cloudbees.plugins.credentials.CredentialsStoreAction$DomainWrapper",
-    "credentials": [
-        {
-            "id": "user-new-cred"
-        }
-    ]
+  "_class": "com.cloudbees.plugins.credentials.CredentialsStoreAction$DomainWrapper",
+  "credentials": [
+    {
+      "id": "user-new-cred"
+    }
+  ]
 }

--- a/test/fixtures/credentialUpdate.xml
+++ b/test/fixtures/credentialUpdate.xml
@@ -2,7 +2,7 @@
   <scope>GLOBAL</scope>
   <id>user-new-cred</id>
   <description>This is an example from REST API</description>
-  <username>admin</username>
+  <username>updated</username>
   <password>
     <secret-redacted/>
   </password>

--- a/test/fixtures/credentials.xml
+++ b/test/fixtures/credentials.xml
@@ -1,0 +1,9 @@
+<com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+  <scope>GLOBAL</scope>
+  <id>my-credentials-example-id</id>
+  <description>This is an example from REST API</description>
+  <username>admin</username>
+  <password>
+    <secret-redacted/>
+  </password>
+</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>

--- a/test/fixtures/folderCreate.xml
+++ b/test/fixtures/folderCreate.xml
@@ -1,0 +1,18 @@
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.858.v898218f3609d">
+    <description/>
+    <properties/>
+    <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+        <views>
+            <hudson.model.AllView>
+                <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+                <name>All</name>
+                <filterExecutors>false</filterExecutors>
+                <filterQueue>false</filterQueue>
+                <properties class="hudson.model.View$PropertyList"/>
+            </hudson.model.AllView>
+        </views>
+        <tabBar class="hudson.views.DefaultViewsTabBar"/>
+    </folderViews>
+    <healthMetrics/>
+    <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/test/helper.js
+++ b/test/helper.js
@@ -23,6 +23,7 @@ async function setup(opts) {
   test.jobName = unique("job");
   test.nodeName = unique("node");
   test.viewName = unique("view");
+  test.folderName = unique("folder");
 
   if (!NOCK_OFF) {
     nock.disableNetConnect();
@@ -33,6 +34,10 @@ async function setup(opts) {
 
   if (opts.job) {
     promises.push(jenkins.job.create(test.jobName, fixtures.jobCreate));
+  }
+
+  if (opts.folder){
+    promises.push(jenkins.job.create(test.folderName, fixtures.folderCreate));
   }
 
   if (opts.node) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -87,9 +87,9 @@ async function cleanup(opts) {
     return test.jenkins.view.list();
   };
 
-  // jobs.listCredentials = async () => {
-  //   return test.jenkins.credentials.list();
-  // };
+  jobs.listSystemCredentials = async () => {
+    return test.jenkins.credentials.list("manage", "system", "_");
+  };
 
   jobs.destroyJobs = [
     "listJobs",
@@ -139,17 +139,17 @@ async function cleanup(opts) {
     },
   ];
 
-  // jobs.destroySystemCredentials = [
-  //   "listSystemCredentials",
-  //   async (results) => {
-  //     return Promise.all(
-  //       results.listJobs
-  //         .map((job) => job.name)
-  //         .filter((name) => name.match(/^system-new-cred-/))
-  //         .map((name) => test.jenkins.job.destroy(name))
-  //     );
-  //   },
-  // ];
+  jobs.destroySystemCredentials = [
+    "listSystemCredentials",
+    async (results) => {
+      return Promise.all(
+        results.listSystemCredentials
+          .map((credential) => credential.id)
+          .filter((id) => id.match(/^user-new-cred/))
+          .map((id) => test.jenkins.credentials.destroy(id, "manage", "system", "_"))
+      );
+    },
+  ];
 
   return auto(jobs);
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -87,6 +87,10 @@ async function cleanup(opts) {
     return test.jenkins.view.list();
   };
 
+  // jobs.listCredentials = async () => {
+  //   return test.jenkins.credentials.list();
+  // };
+
   jobs.destroyJobs = [
     "listJobs",
     async (results) => {
@@ -134,6 +138,18 @@ async function cleanup(opts) {
       );
     },
   ];
+
+  // jobs.destroySystemCredentials = [
+  //   "listSystemCredentials",
+  //   async (results) => {
+  //     return Promise.all(
+  //       results.listJobs
+  //         .map((job) => job.name)
+  //         .filter((name) => name.match(/^system-new-cred-/))
+  //         .map((name) => test.jenkins.job.destroy(name))
+  //     );
+  //   },
+  // ];
 
   return auto(jobs);
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -123,6 +123,18 @@ async function cleanup(opts) {
     },
   ];
 
+  jobs.destroyFolders = [
+    "listJobs",
+    async (results) => {
+      return Promise.all(
+        results.listJobs
+          .map((job) => job.name)
+          .filter((name) => name.match(/^test-folder-/))
+          .map((name) => test.jenkins.job.destroy(name))
+      );
+    },
+  ];
+
   return auto(jobs);
 }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -36,7 +36,7 @@ async function setup(opts) {
     promises.push(jenkins.job.create(test.jobName, fixtures.jobCreate));
   }
 
-  if (opts.folder){
+  if (opts.folder) {
     promises.push(jenkins.job.create(test.folderName, fixtures.folderCreate));
   }
 
@@ -146,7 +146,9 @@ async function cleanup(opts) {
         results.listSystemCredentials
           .map((credential) => credential.id)
           .filter((id) => id.match(/^user-new-cred/))
-          .map((id) => test.jenkins.credentials.destroy(id, "manage", "system", "_"))
+          .map((id) =>
+            test.jenkins.credentials.destroy(id, "manage", "system", "_")
+          )
       );
     },
   ];

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -477,12 +477,12 @@ describe("jenkins", function () {
     });
   });
 
-  describe('credentials', function () {
+  describe("credentials", function () {
     before(async function () {
-      return helper.setup({ job: false, test: this , folder: true});
+      return helper.setup({ job: false, test: this, folder: true });
     });
 
-    describe('folder', function () {
+    describe("folder", function () {
       it("should create credentials", async function () {
         const folder = this.folderName;
         const store = "folder";
@@ -490,21 +490,41 @@ describe("jenkins", function () {
         const id = "user-new-cred";
 
         this.nock
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(404)
-          .post(`/job/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
-              fixtures.credentialCreate)
+          .post(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
+            fixtures.credentialCreate
+          )
           .reply(200)
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(200);
 
-      
-        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const before = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(before).equal(false);
 
-        await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
+        await this.jenkins.credentials.create(
+          folder,
+          store,
+          domain,
+          fixtures.credentialCreate
+        );
 
-        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const after = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(after).equal(true);
       });
 
@@ -515,10 +535,17 @@ describe("jenkins", function () {
         const id = "user-new-cred";
 
         this.nock
-          .get(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialCreate);
 
-        const config = await this.jenkins.credentials.config(id, folder, store, domain);
+        const config = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(config).be.type("string");
         should(config).equals(fixtures.credentialCreate);
       });
@@ -530,23 +557,45 @@ describe("jenkins", function () {
         const id = "user-new-cred";
 
         this.nock
-          .get(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialCreate)
-          .post(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .post(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200)
-          .get(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialUpdate);
 
-        const before = await this.jenkins.credentials.config(id, folder, store, domain);
+        const before = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
 
         const config = before.replace(
-            "<username>admin</username>",
-            "<username>updated</username>"
-          );
+          "<username>admin</username>",
+          "<username>updated</username>"
+        );
 
-        await this.jenkins.credentials.config(id, folder, store, domain, config);
+        await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain,
+          config
+        );
 
-        const after = await this.jenkins.credentials.config(id, folder, store, domain);
+        const after = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(config).be.type("string");
         should(config).equals(fixtures.credentialUpdate);
       });
@@ -556,8 +605,11 @@ describe("jenkins", function () {
         const store = "folder";
         const domain = "_";
 
-        this.nock.get(`/job/${folder}/credentials/store/${store}/domain/${domain}/api/json?tree=credentials[id]`)
-        .reply(200, fixtures.credentialList);
+        this.nock
+          .get(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/api/json?tree=credentials[id]`
+          )
+          .reply(200, fixtures.credentialList);
 
         const data = await this.jenkins.credentials.list(folder, store, domain);
         should(data).not.be.empty();
@@ -571,103 +623,171 @@ describe("jenkins", function () {
         const store = "folder";
         const domain = "_";
         const id = "user-new-cred";
-        
+
         this.nock
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(200)
-          .delete(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .delete(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200)
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(404);
 
         const jobs = {};
 
-        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const before = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(before).equal(true);
 
         await this.jenkins.credentials.destroy(id, folder, store, domain);
 
-        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const after = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(after).equal(false);
       });
     });
 
-    describe('system', function () {
+    describe("system", function () {
       it("should create system credentials", async function () {
-        const folder = "manage"
+        const folder = "manage";
         const store = "system";
         const domain = "_";
         const id = "user-new-cred";
 
         this.nock
-          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(404)
-          .post(`/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
-              fixtures.credentialCreate)
+          .post(
+            `/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
+            fixtures.credentialCreate
+          )
           .reply(200)
-          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(200);
 
-      
-        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const before = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(before).equal(false);
 
-        await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
+        await this.jenkins.credentials.create(
+          folder,
+          store,
+          domain,
+          fixtures.credentialCreate
+        );
 
-        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const after = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(after).equal(true);
       });
 
       it("should get system credentials", async function () {
-        const folder = "manage"
+        const folder = "manage";
         const store = "system";
         const domain = "_";
         const id = "user-new-cred";
 
         this.nock
-          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialCreate);
 
-        const config = await this.jenkins.credentials.config(id, folder, store, domain);
+        const config = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(config).be.type("string");
         should(config).equals(fixtures.credentialCreate);
       });
 
       it("should update system credentials", async function () {
-        const folder = "manage"
+        const folder = "manage";
         const store = "system";
         const domain = "_";
         const id = "user-new-cred";
 
         this.nock
-          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialCreate)
-          .post(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .post(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200)
-          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .get(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200, fixtures.credentialUpdate);
 
-        const before = await this.jenkins.credentials.config(id, folder, store, domain);
+        const before = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
 
         const config = before.replace(
-            "<username>admin</username>",
-            "<username>updated</username>"
-          );
+          "<username>admin</username>",
+          "<username>updated</username>"
+        );
 
-        await this.jenkins.credentials.config(id, folder, store, domain, config);
+        await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain,
+          config
+        );
 
-        const after = await this.jenkins.credentials.config(id, folder, store, domain);
+        const after = await this.jenkins.credentials.config(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(config).be.type("string");
         should(config).equals(fixtures.credentialUpdate);
       });
 
       it("should list system credentials", async function () {
-        const folder = "manage"
+        const folder = "manage";
         const store = "system";
         const domain = "_";
 
-        this.nock.get(`/${folder}/credentials/store/${store}/domain/${domain}/api/json?tree=credentials[id]`)
-        .reply(200, fixtures.credentialList);
+        this.nock
+          .get(
+            `/${folder}/credentials/store/${store}/domain/${domain}/api/json?tree=credentials[id]`
+          )
+          .reply(200, fixtures.credentialList);
 
         const data = await this.jenkins.credentials.list(folder, store, domain);
         should(data).not.be.empty();
@@ -677,27 +797,43 @@ describe("jenkins", function () {
       });
 
       it("should delete system credential", async function () {
-        const folder = "manage"
+        const folder = "manage";
         const store = "system";
         const domain = "_";
         const id = "user-new-cred";
-        
+
         this.nock
-          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(200)
-          .delete(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .delete(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`
+          )
           .reply(200)
-          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .head(
+            `/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`
+          )
           .reply(404);
 
         const jobs = {};
 
-        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const before = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(before).equal(true);
 
         await this.jenkins.credentials.destroy(id, folder, store, domain);
 
-        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const after = await this.jenkins.credentials.exists(
+          id,
+          folder,
+          store,
+          domain
+        );
         should(after).equal(false);
       });
     });

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -597,7 +597,7 @@ describe("jenkins", function () {
         const folder = "manage"
         const store = "system";
         const domain = "_";
-        const id = "system-new-cred";
+        const id = "user-new-cred";
 
         this.nock
           .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
@@ -622,7 +622,7 @@ describe("jenkins", function () {
         const folder = "manage"
         const store = "system";
         const domain = "_";
-        const id = "system-new-cred";
+        const id = "user-new-cred";
 
         this.nock
           .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
@@ -637,7 +637,7 @@ describe("jenkins", function () {
         const folder = "manage"
         const store = "system";
         const domain = "_";
-        const id = "system-new-cred";
+        const id = "user-new-cred";
 
         this.nock
           .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
@@ -680,7 +680,7 @@ describe("jenkins", function () {
         const folder = "manage"
         const store = "system";
         const domain = "_";
-        const id = "system-new-cred";
+        const id = "user-new-cred";
         
         this.nock
           .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -475,6 +475,41 @@ describe("jenkins", function () {
         }, "jenkins: job.list: returned bad data");
       });
     });
+
+    describe('credentials', () => {
+      it("should create credentials", async function () {
+        const folder = this.jobName + "-new";
+        const store = "folder";
+        const domain = "_";
+        const id = "user-new"
+
+        this.nock
+          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .reply(404);
+          // .post(`/createItem?name=${name}`, fixtures.jobCreate)
+          // .reply(200)
+          // .head(`/job/${name}/api/json`)
+          // .reply(200);
+
+        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        should(before).equal(false);
+
+        await this.jenkins.job.create(name, fixtures.jobCreate);
+
+        const after = await this.jenkins.job.exists(name);
+        should(after).equal(true);
+      });
+
+      it("should get credentials config", async function () {
+        this.nock
+          .get(`/job/${this.jobName}/config.xml`)
+          .reply(200, fixtures.jobCreate);
+
+        const config = await this.jenkins.credentials.config(this.jobName);
+        should(config).be.type("string");
+        should(config).containEql("<project>");
+      });
+    });
   });
 
   describe("label", function () {

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -477,38 +477,44 @@ describe("jenkins", function () {
     });
 
     describe('credentials', () => {
+      beforeEach(async function () {
+        return helper.setup({ job: false, test: this , folder: true});
+      });
+
       it("should create credentials", async function () {
-        const folder = this.jobName + "-new";
+        const folder = this.folderName;
         const store = "folder";
         const domain = "_";
-        const id = "user-new"
+        const id = "user-new-cred";
 
         this.nock
           .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
-          .reply(404);
-          // .post(`/createItem?name=${name}`, fixtures.jobCreate)
-          // .reply(200)
-          // .head(`/job/${name}/api/json`)
-          // .reply(200);
+          .reply(404)
+          .post(`/job/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
+              fixtures.credentialCreate)
+          .reply(200)
+          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .reply(200);
 
+      
         const before = await this.jenkins.credentials.exists(id, folder, store, domain);
         should(before).equal(false);
 
-        await this.jenkins.job.create(name, fixtures.jobCreate);
+        await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
 
-        const after = await this.jenkins.job.exists(name);
+        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
         should(after).equal(true);
       });
 
-      it("should get credentials config", async function () {
-        this.nock
-          .get(`/job/${this.jobName}/config.xml`)
-          .reply(200, fixtures.jobCreate);
+      // it("should get credentials config", async function () {
+      //   this.nock
+      //     .get(`/job/${this.jobName}/config.xml`)
+      //     .reply(200, fixtures.jobCreate);
 
-        const config = await this.jenkins.credentials.config(this.jobName);
-        should(config).be.type("string");
-        should(config).containEql("<project>");
-      });
+      //   const config = await this.jenkins.credentials.config(this.jobName);
+      //   should(config).be.type("string");
+      //   should(config).containEql("<project>");
+      // });
     });
   });
 

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -506,6 +506,29 @@ describe("jenkins", function () {
         should(after).equal(true);
       });
 
+      it("should create system credentials", async function () {
+        const domain = "_";
+        const id = "system-new-cred";
+
+        this.nock
+          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+          .reply(404)
+          .post(`/manage/credentials/store/system/domain/${domain}/createCredentials`,
+              fixtures.credentialCreate)
+          .reply(200)
+          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+          .reply(200);
+
+          const before = await this.jenkins.credentials.systemExist(id, domain);
+          should(before).equal(false);
+  
+          await this.jenkins.credentials.systemCreate(domain, fixtures.credentialCreate);
+  
+          const after = await this.jenkins.credentials.systemExist(id, domain);
+          should(after).equal(true);
+      });
+
+
       // it("should get credentials config", async function () {
       //   this.nock
       //     .get(`/job/${this.jobName}/config.xml`)

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -475,69 +475,58 @@ describe("jenkins", function () {
         }, "jenkins: job.list: returned bad data");
       });
     });
+  });
 
-    describe('credentials', () => {
-      beforeEach(async function () {
-        return helper.setup({ job: false, test: this , folder: true});
-      });
+  describe('credentials', () => {
+    beforeEach(async function () {
+      return helper.setup({ job: false, test: this , folder: true});
+    });
 
-      it("should create credentials", async function () {
-        const folder = this.folderName;
-        const store = "folder";
-        const domain = "_";
-        const id = "user-new-cred";
+    it("should create credentials", async function () {
+      const folder = this.folderName;
+      const store = "folder";
+      const domain = "_";
+      const id = "user-new-cred";
 
-        this.nock
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
-          .reply(404)
-          .post(`/job/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
-              fixtures.credentialCreate)
-          .reply(200)
-          .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
-          .reply(200);
+      this.nock
+        .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+        .reply(404)
+        .post(`/job/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
+            fixtures.credentialCreate)
+        .reply(200)
+        .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+        .reply(200);
 
-      
-        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+    
+      const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+      should(before).equal(false);
+
+      await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
+
+      const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+      should(after).equal(true);
+    });
+
+    it("should create system credentials", async function () {
+      const domain = "_";
+      const id = "system-new-cred";
+
+      this.nock
+        .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+        .reply(404)
+        .post(`/manage/credentials/store/system/domain/${domain}/createCredentials`,
+            fixtures.credentialCreate)
+        .reply(200)
+        .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+        .reply(200);
+
+        const before = await this.jenkins.credentials.systemExist(id, domain);
         should(before).equal(false);
 
-        await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
+        await this.jenkins.credentials.systemCreate(domain, fixtures.credentialCreate);
 
-        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        const after = await this.jenkins.credentials.systemExist(id, domain);
         should(after).equal(true);
-      });
-
-      it("should create system credentials", async function () {
-        const domain = "_";
-        const id = "system-new-cred";
-
-        this.nock
-          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
-          .reply(404)
-          .post(`/manage/credentials/store/system/domain/${domain}/createCredentials`,
-              fixtures.credentialCreate)
-          .reply(200)
-          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
-          .reply(200);
-
-          const before = await this.jenkins.credentials.systemExist(id, domain);
-          should(before).equal(false);
-  
-          await this.jenkins.credentials.systemCreate(domain, fixtures.credentialCreate);
-  
-          const after = await this.jenkins.credentials.systemExist(id, domain);
-          should(after).equal(true);
-      });
-
-
-      // it("should get credentials config", async function () {
-      //   this.nock
-      //     .get(`/job/${this.jobName}/config.xml`)
-      //     .reply(200, fixtures.jobCreate);
-
-      //   const config = await this.jenkins.credentials.config(this.jobName);
-      //   should(config).be.type("string");
-      //   should(config).containEql("<project>");
-      // });
     });
   });
 

--- a/test/jenkins.js
+++ b/test/jenkins.js
@@ -576,7 +576,7 @@ describe("jenkins", function () {
           .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
           .reply(200)
           .delete(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
-          .reply(302, "")
+          .reply(200)
           .head(`/job/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
           .reply(404);
 
@@ -592,27 +592,113 @@ describe("jenkins", function () {
       });
     });
 
-    describe("system", () => {
+    describe('system', function () {
       it("should create system credentials", async function () {
+        const folder = "manage"
+        const store = "system";
         const domain = "_";
         const id = "system-new-cred";
 
         this.nock
-          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
           .reply(404)
-          .post(`/manage/credentials/store/system/domain/${domain}/createCredentials`,
+          .post(`/${folder}/credentials/store/${store}/domain/${domain}/createCredentials`,
               fixtures.credentialCreate)
           .reply(200)
-          .head(`/manage/credentials/store/system/domain/${domain}/credential/${id}/api/json`)
+          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
           .reply(200);
 
-          const before = await this.jenkins.credentials.systemExist(id, domain);
-          should(before).equal(false);
+      
+        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        should(before).equal(false);
 
-          await this.jenkins.credentials.systemCreate(domain, fixtures.credentialCreate);
+        await this.jenkins.credentials.create(folder, store, domain, fixtures.credentialCreate);
 
-          const after = await this.jenkins.credentials.systemExist(id, domain);
-          should(after).equal(true);
+        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        should(after).equal(true);
+      });
+
+      it("should get system credentials", async function () {
+        const folder = "manage"
+        const store = "system";
+        const domain = "_";
+        const id = "system-new-cred";
+
+        this.nock
+          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .reply(200, fixtures.credentialCreate);
+
+        const config = await this.jenkins.credentials.config(id, folder, store, domain);
+        should(config).be.type("string");
+        should(config).equals(fixtures.credentialCreate);
+      });
+
+      it("should update system credentials", async function () {
+        const folder = "manage"
+        const store = "system";
+        const domain = "_";
+        const id = "system-new-cred";
+
+        this.nock
+          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .reply(200, fixtures.credentialCreate)
+          .post(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .reply(200)
+          .get(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .reply(200, fixtures.credentialUpdate);
+
+        const before = await this.jenkins.credentials.config(id, folder, store, domain);
+
+        const config = before.replace(
+            "<username>admin</username>",
+            "<username>updated</username>"
+          );
+
+        await this.jenkins.credentials.config(id, folder, store, domain, config);
+
+        const after = await this.jenkins.credentials.config(id, folder, store, domain);
+        should(config).be.type("string");
+        should(config).equals(fixtures.credentialUpdate);
+      });
+
+      it("should list system credentials", async function () {
+        const folder = "manage"
+        const store = "system";
+        const domain = "_";
+
+        this.nock.get(`/${folder}/credentials/store/${store}/domain/${domain}/api/json?tree=credentials[id]`)
+        .reply(200, fixtures.credentialList);
+
+        const data = await this.jenkins.credentials.list(folder, store, domain);
+        should(data).not.be.empty();
+        for (const credential of data) {
+          should(credential).have.properties("id");
+        }
+      });
+
+      it("should delete system credential", async function () {
+        const folder = "manage"
+        const store = "system";
+        const domain = "_";
+        const id = "system-new-cred";
+        
+        this.nock
+          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .reply(200)
+          .delete(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/config.xml`)
+          .reply(200)
+          .head(`/${folder}/credentials/store/${store}/domain/${domain}/credential/${id}/api/json`)
+          .reply(404);
+
+        const jobs = {};
+
+        const before = await this.jenkins.credentials.exists(id, folder, store, domain);
+        should(before).equal(true);
+
+        await this.jenkins.credentials.destroy(id, folder, store, domain);
+
+        const after = await this.jenkins.credentials.exists(id, folder, store, domain);
+        should(after).equal(false);
       });
     });
   });


### PR DESCRIPTION
Added Credentials API that supports:
- create
- exist
- config
- destroy
- list

All operations can be done on a folder as a system credential.
Added Credential plugin.
Cleaning all system credentials after a test.
VScode debug and run configuration for nock and without nock for easy debugging